### PR TITLE
Update TelegramReferralBot.deps.json

### DIFF
--- a/TelegramReferralBot/netcoreapp2.1/TelegramReferralBot.deps.json
+++ b/TelegramReferralBot/netcoreapp2.1/TelegramReferralBot.deps.json
@@ -8,7 +8,7 @@
     ".NETCoreApp,Version=v2.1": {
       "TelegramReferralBot/1.0.0": {
         "dependencies": {
-          "Telegram.Bot": "15.5.1"
+          "Telegram.Bot": "16.0.2"
         },
         "runtime": {
           "TelegramReferralBot.dll": {}
@@ -549,15 +549,15 @@
           "System.Runtime": "4.3.0"
         }
       },
-      "Telegram.Bot/15.5.1": {
+      "Telegram.Bot/16.0.2": {
         "dependencies": {
           "Newtonsoft.Json": "11.0.2",
           "System.Net.Requests": "4.3.0"
         },
         "runtime": {
           "lib/netstandard1.1/Telegram.Bot.dll": {
-            "assemblyVersion": "15.5.1.0",
-            "fileVersion": "15.5.1.0"
+            "assemblyVersion": "16.0.2",
+            "fileVersion": "16.0.2"
           }
         }
       }
@@ -919,12 +919,12 @@
       "path": "system.threading.tasks/4.3.0",
       "hashPath": "system.threading.tasks.4.3.0.nupkg.sha512"
     },
-    "Telegram.Bot/15.5.1": {
+    "Telegram.Bot/16.0.2": {
       "type": "package",
       "serviceable": true,
       "sha512": "sha512-GqZPbJ2gomved+q9Qcu6Vj346Gv/73TzJCqt/k5HxlY8mipwbrY9qWpuzJPIgfCOb+NvbHqE3iaPyZmJFRTxoQ==",
-      "path": "telegram.bot/15.5.1",
-      "hashPath": "telegram.bot.15.5.1.nupkg.sha512"
+      "path": "telegram.bot/16.0.2",
+      "hashPath": "telegram.bot.16.0.2.nupkg.sha512"
     }
   }
 }


### PR DESCRIPTION
Old version of dependency TelegramBot has strict requirements for the length of bot token, updating to a newer version of it should fix it